### PR TITLE
Update endotyper.py

### DIFF
--- a/EndotypY/endotyper.py
+++ b/EndotypY/endotyper.py
@@ -159,7 +159,7 @@ class Endotyper:
                                        self.idx_ensembl)
         
         self.disease_module, self.connected_subgraph = extract_connected_module(self.network, seeds,
-                                                           rwr_results, k=k, check_connectivity=True)
+                                                           rwr_results, k=k)
 
         print(f"Connected module extracted with {self.connected_subgraph.number_of_nodes()} nodes and {self.connected_subgraph.number_of_edges()} edges")
         return self


### PR DESCRIPTION
When I ran this endotyper.py script i got the following error message that broke the run: [ERROR] EndotypY analysis failed: extract_connected_module() got an unexpected keyword argument 'check_connectivity'

In line 161 a function call to extract_ connected_module includes the argument check_connectivity = True. The function is defined in rwr.py in line 52 without that argument, so this patch just deletes that argument.